### PR TITLE
Fix Server Error in Show Page When Ratings are Nil

### DIFF
--- a/app/services/chart_data_builder.rb
+++ b/app/services/chart_data_builder.rb
@@ -68,7 +68,7 @@ class ChartDataBuilder
   private
 
   def season_average(avg_attr)
-    return @season.avg_adj_offensive_efficiency - @season.avg_adj_defensive_efficiency if avg_attr == 'rating'
+    return (@season.avg_adj_offensive_efficiency || 0).to_f - (@season.avg_adj_defensive_efficiency || 0).to_f if avg_attr == 'rating'
 
     @season.try(avg_attr) || 0
   end

--- a/spec/services/chart_data_builder_spec.rb
+++ b/spec/services/chart_data_builder_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChartDataBuilder do
+  describe '#reference_lines' do
+    let(:season) do
+      instance_double(
+        Season,
+        avg_adj_offensive_efficiency: nil,
+        avg_adj_defensive_efficiency: nil,
+        team_seasons: TeamSeason.none
+      )
+    end
+    let(:snapshots) do
+      [
+        instance_double(TeamRatingSnapshot, snapshot_date: Date.new(2026, 1, 1), rating: 5.0),
+        instance_double(TeamRatingSnapshot, snapshot_date: Date.new(2026, 1, 2), rating: 6.0)
+      ]
+    end
+
+    it 'does not raise when season adjusted averages are nil for rating charts' do
+      builder = described_class.new(snapshots: snapshots, season: season, selected_stat: 'rating')
+
+      expect { builder.reference_lines }.not_to raise_error
+      expect(builder.reference_lines[:avg].map(&:last)).to eq([0.0, 0.0])
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of rating calculations by implementing proper null handling for season efficiency metrics. Charts now gracefully handle cases where efficiency data is unavailable.

* **Tests**
  * Expanded test coverage to ensure rating charts function correctly even when adjusted average data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->