### PR TITLE
Fix backfill bug

### DIFF
--- a/app/services/prophet_ratings/overall_ratings_calculator.rb
+++ b/app/services/prophet_ratings/overall_ratings_calculator.rb
@@ -116,7 +116,7 @@ module ProphetRatings
 
     def enough_finalized_data_for_adjustments?(as_of:)
       TeamGame
-        .joins(:game)
+        .joins(:game, :team_season)
         .where(team_seasons: { season_id: @season.id })
         .where(games: { status: Game.statuses[:final], start_time: ..as_of })
         .group(:team_season_id)

--- a/spec/services/prophet_ratings/overall_ratings_calculator_spec.rb
+++ b/spec/services/prophet_ratings/overall_ratings_calculator_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProphetRatings::OverallRatingsCalculator, type: :service do
+  describe '#enough_finalized_data_for_adjustments?' do
+    let(:season) { create(:season) }
+    let(:as_of) { season.start_date + 30.days }
+    let(:calculator) { described_class.new(season) }
+
+    it 'returns false (and does not raise) when there are no team games' do
+      expect { calculator.send(:enough_finalized_data_for_adjustments?, as_of:) }.not_to raise_error
+      expect(calculator.send(:enough_finalized_data_for_adjustments?, as_of:)).to be(false)
+    end
+
+    it 'returns true when at least two teams have two finalized games each' do
+      team_season_one = create(:team_season, season:)
+      team_season_two = create(:team_season, season:)
+
+      2.times do |i|
+        game_one = create(:game, season:, status: :final, start_time: season.start_date + (i + 1).days)
+        create(:team_game, game: game_one, team_season: team_season_one, team: team_season_one.team, home: i.zero?)
+
+        game_two = create(:game, season:, status: :final, start_time: season.start_date + (i + 3).days)
+        create(:team_game, game: game_two, team_season: team_season_two, team: team_season_two.team, home: i.zero?)
+      end
+
+      expect(calculator.send(:enough_finalized_data_for_adjustments?, as_of:)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overall ratings calculations now correctly filter team season data, ensuring proper identification of finalized games when determining adjustment eligibility for specific seasons.

* **Tests**
  * Added comprehensive test coverage for the ratings calculation service, validating behavior with no finalized games and multiple consecutive seasons of game data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->