### PR TITLE
Add ResumeSeasonRatingsJob to Handle Interrupted Runs

### DIFF
--- a/app/jobs/resume_season_ratings_job.rb
+++ b/app/jobs/resume_season_ratings_job.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class ResumeSeasonRatingsJob < ApplicationJob
+  queue_as :default
+
+  # Backfills ratings, predictions, and finalized game-derived values for a season.
+  # Unlike GenerateSeasonRatingsJob, this does not clear existing predictions/snapshots.
+  def perform(season_id, run_preseason: false, start_date: nil, end_date: nil)
+    season = resolve_season(season_id)
+    ratings_config_version = RatingsConfigVersion.ensure_current!
+    date_range = backfill_date_range(season:, ratings_config_version:, start_date:, end_date:)
+    return if date_range.nil?
+
+    maybe_initialize_preseason!(season, ratings_config_version, run_preseason)
+
+    Rails.logger.info do
+      "Resuming ratings backfill for season #{season.year}: #{date_range.begin}..#{date_range.end}"
+    end
+
+    backfill_date_range!(season, date_range)
+
+    Rails.logger.info { "✅ Done resumable ratings backfill for season #{season.year}" }
+  end
+
+  private
+
+  def resolve_season(season)
+    return season if season.is_a?(Season)
+
+    Season.find(season)
+  end
+
+  def backfill_date_range(season:, ratings_config_version:, start_date:, end_date:)
+    backfill_end_date = [coerce_date(end_date) || season.end_date, season.end_date].min
+    backfill_start_date = coerce_date(start_date) || resume_start_date(season, ratings_config_version)
+    backfill_start_date = [backfill_start_date, season.start_date].max
+
+    if backfill_start_date > backfill_end_date
+      Rails.logger.info do
+        "Skipping resumable ratings backfill for #{season.year}: computed empty range " \
+          "(start=#{backfill_start_date}, end=#{backfill_end_date})"
+      end
+      return nil
+    end
+
+    backfill_start_date..backfill_end_date
+  end
+
+  def resume_start_date(season, ratings_config_version)
+    latest_snapshot_date = season.team_rating_snapshots.where(ratings_config_version:).maximum(:snapshot_date)
+    latest_snapshot_date || season.start_date
+  end
+
+  def should_initialize_preseason?(season, ratings_config_version)
+    season.team_rating_snapshots.where(ratings_config_version:).none?
+  end
+
+  def maybe_initialize_preseason!(season, ratings_config_version, run_preseason)
+    return unless run_preseason && should_initialize_preseason?(season, ratings_config_version)
+
+    initialize_preseason_ratings!(season)
+  end
+
+  def backfill_date_range!(season, date_range)
+    date_range.each do |date|
+      Rails.logger.debug { "Backfilling for #{date}" }
+      games = season.games.where(start_time: date.all_day)
+      ProphetRatings::OverallRatingsCalculator.new(season).call(as_of: date)
+      games.each(&:generate_prediction!)
+      games.each { |game| game.finalize if game.final? }
+    end
+  end
+
+  def initialize_preseason_ratings!(season)
+    ProphetRatings::PreseasonInitializer.new(season).call
+  end
+
+  def coerce_date(value)
+    return value if value.is_a?(Date)
+    return value.to_date if value.respond_to?(:to_date)
+    return if value.blank?
+
+    Date.parse(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/services/prophet_ratings/game_predictor.rb
+++ b/app/services/prophet_ratings/game_predictor.rb
@@ -79,8 +79,9 @@ module ProphetRatings
       return unless home_rating_snapshot && away_rating_snapshot
 
       @home_expected_ortg ||=
-        (home_rating_snapshot.adj_offensive_efficiency - season_average_efficiency) +
-        (away_rating_snapshot.adj_defensive_efficiency - season_average_efficiency) +
+        home_rating_snapshot.adj_offensive_efficiency +
+        away_rating_snapshot.adj_defensive_efficiency -
+        season_average_efficiency +
         home_offense_boost
     end
 
@@ -92,8 +93,9 @@ module ProphetRatings
       return unless home_rating_snapshot && away_rating_snapshot
 
       @away_expected_ortg ||=
-        (away_rating_snapshot.adj_offensive_efficiency - season_average_efficiency) +
-        (home_rating_snapshot.adj_defensive_efficiency - season_average_efficiency) +
+        away_rating_snapshot.adj_offensive_efficiency +
+        home_rating_snapshot.adj_defensive_efficiency -
+        season_average_efficiency +
         home_defense_boost
     end
 

--- a/app/services/prophet_ratings/game_simulator.rb
+++ b/app/services/prophet_ratings/game_simulator.rb
@@ -76,8 +76,9 @@ module ProphetRatings
       return unless home_rating_snapshot && away_rating_snapshot
 
       @home_expected_ortg ||=
-        (home_rating_snapshot.adj_offensive_efficiency - season.average_efficiency) +
-        (away_rating_snapshot.adj_defensive_efficiency - season.average_efficiency) +
+        home_rating_snapshot.adj_offensive_efficiency +
+        away_rating_snapshot.adj_defensive_efficiency -
+        season_average_efficiency +
         home_offense_boost
     end
 
@@ -88,8 +89,9 @@ module ProphetRatings
       return unless home_rating_snapshot && away_rating_snapshot
 
       @away_expected_ortg ||=
-        (away_rating_snapshot.adj_offensive_efficiency - season.average_efficiency) +
-        (home_rating_snapshot.adj_defensive_efficiency - season.average_efficiency) +
+        away_rating_snapshot.adj_offensive_efficiency +
+        home_rating_snapshot.adj_defensive_efficiency -
+        season_average_efficiency +
         home_defense_boost
     end
 

--- a/lib/tasks/season_bootstrap.rake
+++ b/lib/tasks/season_bootstrap.rake
@@ -112,15 +112,15 @@ namespace :season do
         start_date: ratings_start_date,
         end_date: ratings_end_date
       )
+
+      puts "Ratings resume complete for #{season.name} (year=#{season.year})"
+      puts "Games in season: #{season.games.count}"
+      puts "Preseason initialized: #{run_preseason}"
+      puts "Ratings window override: #{ratings_start_date || 'auto'}..#{ratings_end_date || 'season end'}"
     else
       puts 'Skipping ratings resume: no games found for this season. ' \
            'Run season:sync_games first.'
     end
-
-    puts "Ratings resume complete for #{season.name} (year=#{season.year})"
-    puts "Games in season: #{season.games.count}"
-    puts "Preseason initialized: #{run_preseason}"
-    puts "Ratings window override: #{ratings_start_date || 'auto'}..#{ratings_end_date || 'season end'}"
   end
 
   def env_bool(key, default:)

--- a/lib/tasks/season_bootstrap.rake
+++ b/lib/tasks/season_bootstrap.rake
@@ -13,6 +13,9 @@ namespace :season do
     dedupe_games = env_bool('DEDUPE_GAMES', default: true)
     run_preseason = env_bool('RUN_PRESEASON', default: true)
     run_ratings = env_bool('RUN_RATINGS', default: true)
+    ratings_resume = env_bool('RATINGS_RESUME', default: false)
+    ratings_start_date = parse_date_env('RATINGS_START_DATE')
+    ratings_end_date = parse_date_env('RATINGS_END_DATE')
 
     season = upsert_season_for_year(year)
     season.set_current! unless season.current?
@@ -37,7 +40,16 @@ namespace :season do
 
     if run_ratings
       if season.games.exists?
-        GenerateSeasonRatingsJob.perform_now(season.id, run_preseason: false)
+        if ratings_resume
+          ResumeSeasonRatingsJob.perform_now(
+            season.id,
+            run_preseason: false,
+            start_date: ratings_start_date,
+            end_date: ratings_end_date
+          )
+        else
+          GenerateSeasonRatingsJob.perform_now(season.id, run_preseason: false)
+        end
       else
         puts 'Skipping ratings backfill: no games found for this season. ' \
              'Run with SYNC_GAMES=true first, then rerun RUN_RATINGS=true.'
@@ -51,6 +63,8 @@ namespace :season do
     puts "Games sync window override: #{sync_start_date || 'default'}..#{sync_end_date || 'default'}"
     puts "Games sync resume mode: #{sync_resume}"
     puts "Preseason initialized: #{run_preseason}"
+    puts "Ratings resume mode: #{ratings_resume}"
+    puts "Ratings window override: #{ratings_start_date || 'auto'}..#{ratings_end_date || 'season end'}"
     puts "Current ratings config: #{ratings_config.name} (id=#{ratings_config.id})"
   end
 
@@ -77,6 +91,36 @@ namespace :season do
     puts "Games in season: #{season.games.count}"
     puts "Games sync window override: #{sync_start_date || 'default'}..#{sync_end_date || 'default'}"
     puts "Games sync resume mode: #{sync_resume}"
+  end
+
+  desc 'Resume ratings backfill for an existing season. Supports RATINGS_START_DATE/RATINGS_END_DATE.'
+  task resume_ratings: :environment do
+    year = ENV.fetch('YEAR', Season.current&.year || Date.current.year).to_i
+    abort('YEAR must be a positive integer') unless year.positive?
+
+    season = Season.find_by(year:)
+    abort("No season found for year=#{year}. Run season:bootstrap first.") unless season
+
+    run_preseason = env_bool('RUN_PRESEASON', default: false)
+    ratings_start_date = parse_date_env('RATINGS_START_DATE')
+    ratings_end_date = parse_date_env('RATINGS_END_DATE')
+
+    if season.games.exists?
+      ResumeSeasonRatingsJob.perform_now(
+        season.id,
+        run_preseason:,
+        start_date: ratings_start_date,
+        end_date: ratings_end_date
+      )
+    else
+      puts 'Skipping ratings resume: no games found for this season. ' \
+           'Run season:sync_games first.'
+    end
+
+    puts "Ratings resume complete for #{season.name} (year=#{season.year})"
+    puts "Games in season: #{season.games.count}"
+    puts "Preseason initialized: #{run_preseason}"
+    puts "Ratings window override: #{ratings_start_date || 'auto'}..#{ratings_end_date || 'season end'}"
   end
 
   def env_bool(key, default:)

--- a/spec/jobs/resume_season_ratings_job_spec.rb
+++ b/spec/jobs/resume_season_ratings_job_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResumeSeasonRatingsJob do
+  let(:season) do
+    create(
+      :season,
+      year: 2099,
+      start_date: Date.new(2098, 11, 1),
+      end_date: Date.new(2098, 11, 3)
+    )
+  end
+  let(:ratings_config_version) { create(:ratings_config_version, current: true) }
+
+  before do
+    allow(RatingsConfigVersion).to receive(:ensure_current!).and_return(ratings_config_version)
+  end
+
+  it 'resumes from latest snapshot date for the current ratings config when no start date is provided' do
+    team_season = create(:team_season, season:)
+    create(
+      :team_rating_snapshot,
+      team_season:,
+      team: team_season.team,
+      season:,
+      ratings_config_version:,
+      snapshot_date: season.start_date + 1.day
+    )
+
+    called_dates = []
+    calculator = instance_double(ProphetRatings::OverallRatingsCalculator)
+    allow(ProphetRatings::OverallRatingsCalculator).to receive(:new).with(season).and_return(calculator)
+    allow(calculator).to receive(:call) { |as_of:| called_dates << as_of }
+
+    described_class.perform_now(season.id)
+
+    expect(called_dates).to eq([season.start_date + 1.day, season.end_date])
+  end
+
+  it 'honors explicit start and end date overrides' do
+    called_dates = []
+    calculator = instance_double(ProphetRatings::OverallRatingsCalculator)
+    allow(ProphetRatings::OverallRatingsCalculator).to receive(:new).with(season).and_return(calculator)
+    allow(calculator).to receive(:call) { |as_of:| called_dates << as_of }
+
+    described_class.perform_now(
+      season.id,
+      start_date: season.start_date,
+      end_date: season.start_date + 1.day
+    )
+
+    expect(called_dates).to eq([season.start_date, season.start_date + 1.day])
+  end
+
+  it 'initializes preseason ratings when requested and no snapshots exist for the current config' do
+    calculator = instance_double(ProphetRatings::OverallRatingsCalculator)
+    allow(ProphetRatings::OverallRatingsCalculator).to receive(:new).with(season).and_return(calculator)
+    allow(calculator).to receive(:call)
+
+    initializer = instance_double(ProphetRatings::PreseasonInitializer, call: true)
+    allow(ProphetRatings::PreseasonInitializer).to receive(:new).with(season).and_return(initializer)
+
+    described_class.perform_now(season.id, run_preseason: true)
+
+    expect(ProphetRatings::PreseasonInitializer).to have_received(:new).with(season)
+    expect(initializer).to have_received(:call)
+  end
+end

--- a/spec/services/prophet_ratings/team_season_stats_aggregator_spec.rb
+++ b/spec/services/prophet_ratings/team_season_stats_aggregator_spec.rb
@@ -68,5 +68,24 @@ RSpec.describe ProphetRatings::TeamSeasonStatsAggregator, type: :service do
 
       expect(team_season.turnover_rate).to be_within(0.001).of(expected_avg)
     end
+
+    it 'sets baseline volatility and home boost values for teams with no finalized games' do
+      idle_team_season = create(
+        :team_season,
+        season:,
+        offensive_efficiency_volatility: nil,
+        defensive_efficiency_volatility: nil,
+        home_offense_boost: nil,
+        home_defense_boost: nil
+      )
+
+      described_class.new(season:).run
+      idle_team_season.reload
+
+      expect(idle_team_season.offensive_efficiency_volatility).to eq(11.5)
+      expect(idle_team_season.defensive_efficiency_volatility).to eq(11.5)
+      expect(idle_team_season.home_offense_boost).to eq(2.2)
+      expect(idle_team_season.home_defense_boost).to eq(-2.2)
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume and backfill ratings for existing seasons with optional date range and preseason initialization; background job and CLI task added.
  * Per-season ratings now store home boosts and volatility values for more accurate aggregates.

* **Bug Fixes**
  * Fixed prediction formula to correct expected scoring efficiency.

* **Tests**
  * Added tests covering resume/backfill flow, preseason initialization, and aggregate ratings recalculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->