### PR TITLE
Fix Game Simulator Server Error

### DIFF
--- a/app/controllers/matchups_controller.rb
+++ b/app/controllers/matchups_controller.rb
@@ -39,7 +39,7 @@ class MatchupsController < ApplicationController
         render turbo_stream: turbo_stream.replace('matchup_form', partial: 'shared/error', locals: { message: e.message }),
                status: :unprocessable_entity
       end
-      format.html { redirect_to matchup_path, alert: e.message, status: :unprocessable_entity }
+      format.html { redirect_to matchup_path, alert: e.message, status: :see_other }
     end
   end
 

--- a/app/controllers/matchups_controller.rb
+++ b/app/controllers/matchups_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class MatchupsController < ApplicationController
+  DEFAULT_UPSET_MODIFIER = 1.0
+  MIN_UPSET_MODIFIER = 0.1
+  MAX_UPSET_MODIFIER = 2.0
+
   ##
   # Prepares a list of team options for the current season, ordered alphabetically by school name.
   # @return [void]
@@ -18,26 +22,24 @@ class MatchupsController < ApplicationController
   def submit
     set_prediction_params
 
-    begin
-      case params[:action_type]
-      when 'predict'
-        @prediction = predict_outcome
-      when 'simulate'
-        @prediction = simulate_outcome
-      end
+    case params[:action_type]
+    when 'predict'
+      @prediction = predict_outcome
+    when 'simulate'
+      @simulation = simulate_outcome
+    end
 
-      respond_to do |format|
-        format.turbo_stream
-        format.html { redirect_to matchup_path, alert: 'Turbo not supported. Please use a compatible browser.' }
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to matchup_path, alert: I18n.t('matchups.submit.turbo_not_supported') }
+    end
+  rescue ArgumentError => e
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace('matchup_form', partial: 'shared/error', locals: { message: e.message }),
+               status: :unprocessable_entity
       end
-    rescue ArgumentError => e
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace('matchup_form', partial: 'shared/error', locals: { message: e.message }),
-                 status: :unprocessable_entity
-        end
-        format.html { redirect_to matchup_path, alert: e.message, status: :unprocessable_entity }
-      end
+      format.html { redirect_to matchup_path, alert: e.message, status: :unprocessable_entity }
     end
   end
 
@@ -56,7 +58,19 @@ class MatchupsController < ApplicationController
     @away_snapshot = TeamRatingSnapshot.where(team_season: away_team_season, ratings_config_version: config)
                                        .order(snapshot_date: :desc).first
     @neutral = matchup_params[:neutral] == '1'
-    @upset_modifier = matchup_params[:upset_modifier].presence&.to_f || 1.0
+    @upset_modifier = parse_upset_modifier(matchup_params[:upset_modifier])
+  end
+
+  def parse_upset_modifier(raw_value)
+    return DEFAULT_UPSET_MODIFIER if raw_value.blank?
+
+    value = Float(raw_value)
+  rescue TypeError, ArgumentError
+    raise ArgumentError, "Upset modifier must be a valid number between #{MIN_UPSET_MODIFIER} and #{MAX_UPSET_MODIFIER}"
+  else
+    return value if value.between?(MIN_UPSET_MODIFIER, MAX_UPSET_MODIFIER)
+
+    raise ArgumentError, "Upset modifier must be between #{MIN_UPSET_MODIFIER} and #{MAX_UPSET_MODIFIER}"
   end
 
   ##

--- a/app/services/importer/games_importer.rb
+++ b/app/services/importer/games_importer.rb
@@ -77,7 +77,7 @@ module Importer
             process_team_game(away_game, row[:away_team_stats], away_team_season, home_team_season)
           end
 
-          game.finalize
+          finalize_game_if_possible(game)
           return
         end
 
@@ -90,6 +90,13 @@ module Importer
           away_team_score: game.final? ? game.away_team_score : row[:away_team_score]
         )
         game.scheduled! unless game.final? && finalized_game_data_present?(game)
+      end
+
+      def finalize_game_if_possible(game)
+        game.finalize
+      rescue ProphetRatings::GameFinalizer::MissingDerivedStatsError => e
+        Rails.logger.warn("Skipping finalization for game #{game.id}: #{e.message}")
+        game.scheduled!
       end
 
       def game_complete?(row)

--- a/app/services/prophet_ratings/game_finalizer.rb
+++ b/app/services/prophet_ratings/game_finalizer.rb
@@ -61,15 +61,22 @@ module ProphetRatings
       )
       return unless prediction
 
-      prediction.update!(prediction_error_attributes(prediction))
+      error_attributes = prediction_error_attributes(prediction)
+      return unless error_attributes
+
+      prediction.update!(error_attributes)
     end
 
     def prediction_error_attributes(prediction)
+      home_game = game.home_team_game
+      away_game = game.away_team_game
+      return unless home_game && away_game
+
       {
-        home_offensive_efficiency_error: prediction.home_offensive_efficiency - game.home_team_game.offensive_efficiency,
-        away_offensive_efficiency_error: prediction.away_offensive_efficiency - game.away_team_game.offensive_efficiency,
-        home_defensive_efficiency_error: prediction.home_defensive_efficiency - game.home_team_game.defensive_efficiency,
-        away_defensive_efficiency_error: prediction.away_defensive_efficiency - game.away_team_game.defensive_efficiency,
+        home_offensive_efficiency_error: prediction.home_offensive_efficiency - home_game.offensive_efficiency,
+        away_offensive_efficiency_error: prediction.away_offensive_efficiency - away_game.offensive_efficiency,
+        home_defensive_efficiency_error: prediction.home_defensive_efficiency - home_game.defensive_efficiency,
+        away_defensive_efficiency_error: prediction.away_defensive_efficiency - away_game.defensive_efficiency,
         pace_error: prediction.pace - game.pace
       }
     end

--- a/app/services/prophet_ratings/game_predictor.rb
+++ b/app/services/prophet_ratings/game_predictor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ProphetRatings
-  DEFAULTS = Rails.application.config_for(:defaults).deep_symbolize_keys
+  DEFAULTS = Rails.application.config_for(:defaults).deep_symbolize_keys unless const_defined?(:DEFAULTS)
 
   class GamePredictor
     ##

--- a/app/services/prophet_ratings/game_simulator.rb
+++ b/app/services/prophet_ratings/game_simulator.rb
@@ -95,6 +95,36 @@ module ProphetRatings
         home_defense_boost
     end
 
+    def home_offense_boost
+      return 0 if @neutral
+
+      home_rating_snapshot&.home_offense_boost || default_home_boost
+    end
+
+    def home_defense_boost
+      return 0 if @neutral
+
+      home_rating_snapshot&.home_defense_boost || -default_home_boost
+    end
+
+    ##
+    # Retrieves the default home court advantage value from the ratings configuration.
+    # @return [Numeric] The configured home court advantage value.
+    def default_home_boost
+      @default_home_boost ||= Rails.application.config_for(:ratings).home_court_advantage
+    end
+
+    ##
+    # Returns the season's average efficiency, falling back to a default value if unavailable.
+    # @return [Float] The average efficiency for the season.
+    def season_average_efficiency
+      season.average_efficiency || default_season_average_efficiency
+    end
+
+    def default_season_average_efficiency
+      @default_season_average_efficiency ||= Rails.application.config_for(:defaults).dig('season_defaults', 'average_efficiency')
+    end
+
     ##
     # Returns the total volatility for the home team's offensive rating as calculated by the volatility calculator.
     # @return [Float] The total home offensive volatility value.

--- a/app/services/prophet_ratings/game_simulator.rb
+++ b/app/services/prophet_ratings/game_simulator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ProphetRatings
+  DEFAULTS = Rails.application.config_for(:defaults).deep_symbolize_keys unless const_defined?(:DEFAULTS)
+
   class GameSimulator
     ##
     # Initializes a new game simulator with team rating snapshots, upset modifier, neutral site flag, and season context.
@@ -122,7 +124,7 @@ module ProphetRatings
     end
 
     def default_season_average_efficiency
-      @default_season_average_efficiency ||= Rails.application.config_for(:defaults).dig('season_defaults', 'average_efficiency')
+      @default_season_average_efficiency ||= DEFAULTS[:season_defaults][:average_efficiency]
     end
 
     ##

--- a/app/views/matchups/submit.turbo_stream.erb
+++ b/app/views/matchups/submit.turbo_stream.erb
@@ -9,11 +9,11 @@
     <template>
       <%= render partial: "matchups/simulation_result", formats: [:html], locals: { result: @simulation } %>
     </template>
-  </turbo_stream>
+  </turbo-stream>
 <% else %>
   <turbo-stream target="prediction_result_frame" action="update">
     <template>
       <div class="text-red-600 font-semibold">No result generated.</div>
     </template>
-  </turbo_stream>
+  </turbo-stream>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,6 @@
 
 en:
   hello: "Hello world"
+  matchups:
+    submit:
+      turbo_not_supported: "Turbo not supported. Please use a compatible browser."

--- a/spec/requests/matchups_spec.rb
+++ b/spec/requests/matchups_spec.rb
@@ -26,6 +26,46 @@ RSpec.describe 'Matchups' do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'returns http success (turbo_stream) when simulating a valid matchup' do
+      create(:team_rating_snapshot, team_season: ts1, ratings_config_version: config)
+      create(:team_rating_snapshot, team_season: ts2, ratings_config_version: config)
+      post '/matchup/submit', params: { home_team_id: ts1.id, away_team_id: ts2.id, neutral: '0', action_type: 'simulate' },
+                              as: :turbo_stream
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 422 when upset_modifier is non-numeric' do
+      create(:team_rating_snapshot, team_season: ts1, ratings_config_version: config)
+      create(:team_rating_snapshot, team_season: ts2, ratings_config_version: config)
+
+      post '/matchup/submit', params: {
+        home_team_id: ts1.id,
+        away_team_id: ts2.id,
+        neutral: '0',
+        action_type: 'simulate',
+        upset_modifier: 'not-a-number'
+      }, as: :turbo_stream
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('Upset modifier must be a valid number between 0.1 and 2.0')
+    end
+
+    it 'returns 422 when upset_modifier is outside allowed range' do
+      create(:team_rating_snapshot, team_season: ts1, ratings_config_version: config)
+      create(:team_rating_snapshot, team_season: ts2, ratings_config_version: config)
+
+      post '/matchup/submit', params: {
+        home_team_id: ts1.id,
+        away_team_id: ts2.id,
+        neutral: '0',
+        action_type: 'simulate',
+        upset_modifier: '2.5'
+      }, as: :turbo_stream
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('Upset modifier must be between 0.1 and 2.0')
+    end
+
     it 'returns 422 if snapshots are missing' do
       # No snapshots created
       post '/matchup/submit', params: { home_team_id: ts1.id, away_team_id: ts2.id, neutral: '0', action_type: 'predict' },

--- a/spec/services/importer/games_importer_spec.rb
+++ b/spec/services/importer/games_importer_spec.rb
@@ -120,6 +120,19 @@ RSpec.describe Importer::GamesImporter do
     expect(game.minutes).to be_present
   end
 
+  it 'keeps a game scheduled when derived pace cannot be computed' do
+    invalid_completed_row = completed_row.deep_dup
+    invalid_completed_row[:home_team_stats][:minutes] = 0
+    invalid_completed_row[:away_team_stats][:minutes] = 0
+
+    expect { described_class.import([invalid_completed_row]) }.not_to raise_error
+
+    game = Game.last
+    expect(game).to be_scheduled
+    expect(game.minutes).to be_nil
+    expect(game.pace).to be_nil
+  end
+
   it 'does not downgrade an existing final game when an incomplete row is imported later' do
     described_class.import([completed_row])
     game = Game.last

--- a/spec/services/prophet_ratings/game_finalizer_spec.rb
+++ b/spec/services/prophet_ratings/game_finalizer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProphetRatings::GameFinalizer do
+  describe '#finalize_prediction!' do
+    it 'does not update prediction when error attributes are unavailable' do
+      prediction = instance_double(Prediction)
+      predictions_relation = instance_double(ActiveRecord::Associations::CollectionProxy)
+      game = instance_double(Game, predictions: predictions_relation)
+      finalizer = described_class.new(game)
+
+      allow(predictions_relation).to receive(:find_by).and_return(prediction)
+      allow(finalizer).to receive_messages(
+        home_snapshot: instance_double(TeamRatingSnapshot),
+        away_snapshot: instance_double(TeamRatingSnapshot)
+      )
+      allow(finalizer).to receive(:prediction_error_attributes).with(prediction).and_return(nil)
+      allow(prediction).to receive(:update!)
+
+      finalizer.send(:finalize_prediction!)
+
+      expect(prediction).not_to have_received(:update!)
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Turbo Stream markup in matchup submission responses for proper HTML rendering.
  * Importer no longer crashes on games missing derived stats; such games are left scheduled instead.

* **Improvements**
  * Centralized and tightened upset modifier validation with clear 0.1–2.0 range errors.
  * Improved simulation/prediction handling and home/away/season defaults for more consistent results.

* **New Features**
  * Added a browser compatibility notice when Turbo Streams are not supported.

* **Tests**
  * Added request and importer tests covering simulation paths and upset_modifier/derived-stats edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->