### PR TITLE
Default nil locations to non-neutral

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -25,7 +25,7 @@
 
     <div class="mt-4">
       <p class="text-gray-600 text-center">Date: <%= @game.start_time.strftime("%B %d, %Y") %></p>
-      <% if @game.location %>
+      <% if @game.location.present? %>
         <p class="text-gray-600 text-center">Location: <%= @game.location %></p>
       <% end %>
     </div>

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -15,4 +15,54 @@ RSpec.describe 'Games' do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'GET /games/:id' do
+    let(:season) { create(:season, :current) }
+    let(:home_team) { create(:team, school: 'Home Team', slug: 'home-team') }
+    let(:away_team) { create(:team, school: 'Away Team', slug: 'away-team') }
+    let(:home_team_season) { create(:team_season, team: home_team, season:) }
+    let(:away_team_season) { create(:team_season, team: away_team, season:) }
+    let(:location) { nil }
+    let(:game) do
+      create(
+        :game,
+        season:,
+        start_time: Date.current.beginning_of_day + 12.hours,
+        status: :final,
+        minutes: 40,
+        home_team_score: 70,
+        away_team_score: 65,
+        home_team_name: home_team.school,
+        away_team_name: away_team.school,
+        location:
+      )
+    end
+
+    before do
+      create(:team_game, game:, team: home_team, team_season: home_team_season, home: true, points: 70)
+      create(:team_game, game:, team: away_team, team_season: away_team_season, home: false, points: 65)
+    end
+
+    context 'when location is blank' do
+      let(:location) { '' }
+
+      it 'does not render the location header' do
+        get "/games/#{game.id}"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include('Location:')
+      end
+    end
+
+    context 'when location is present' do
+      let(:location) { 'Test Arena' }
+
+      it 'renders the location header and value' do
+        get "/games/#{game.id}"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('Location: Test Arena')
+      end
+    end
+  end
 end

--- a/spec/services/prophet_ratings/game_finalizer_spec.rb
+++ b/spec/services/prophet_ratings/game_finalizer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProphetRatings::GameFinalizer, type: :service do
+  describe '#calculated_neutrality' do
+    subject(:calculated_neutrality) { described_class.new(game).send(:calculated_neutrality) }
+
+    let(:season) { create(:season) }
+    let(:home_team) do
+      create(
+        :team,
+        school: 'Home School',
+        slug: 'home-school',
+        location: 'Home City, HS',
+        home_venue: 'Home Arena'
+      )
+    end
+    let(:away_team) { create(:team, school: 'Away School', slug: 'away-school') }
+    let(:home_team_season) { create(:team_season, season:, team: home_team) }
+    let(:away_team_season) { create(:team_season, season:, team: away_team) }
+    let(:location) { 'Neutral Court' }
+    let(:neutral) { nil }
+    let(:game) do
+      create(
+        :game,
+        season:,
+        status: :final,
+        start_time: season.start_date + 1.day,
+        home_team_name: home_team.school,
+        away_team_name: away_team.school,
+        location:,
+        neutral:
+      )
+    end
+
+    before do
+      create(:team_game, game:, team: home_team, team_season: home_team_season, home: true)
+      create(:team_game, game:, team: away_team, team_season: away_team_season, home: false)
+    end
+
+    context 'when location is unknown and no override exists' do
+      let(:location) { '' }
+
+      it 'defaults to non-neutral' do
+        expect(calculated_neutrality).to be(false)
+      end
+    end
+
+    context 'when location is unknown and game neutrality is explicitly set' do
+      let(:location) { nil }
+      let(:neutral) { true }
+
+      it 'preserves the explicit override' do
+        expect(calculated_neutrality).to be(true)
+      end
+    end
+
+    context 'when location is the home venue' do
+      let(:location) { 'Home Arena' }
+
+      it 'is not neutral' do
+        expect(calculated_neutrality).to be(false)
+      end
+    end
+
+    context 'when location is away from home city and venue' do
+      let(:location) { 'Neutral Court' }
+
+      it 'is neutral' do
+        expect(calculated_neutrality).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Location field display on game pages to show only when location data is available, preventing blank entries from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->