### PR TITLE
Fix import duplicates after datetime enrichment

### DIFF
--- a/app/services/importer/games_importer.rb
+++ b/app/services/importer/games_importer.rb
@@ -14,20 +14,25 @@ module Importer
       private
 
       def find_existing_game(row, date)
-        find_game_by_box_score_url(row[:url]) ||
+        find_game_by_unique_url(row[:url]) ||
           find_game_by_teams_and_date(row[:home_team], row[:away_team], date) ||
           find_game_by_teams_and_legacy_date(row[:home_team], row[:away_team], date) ||
           find_neutral_game_by_reversed_teams(row, date)
       end
 
-      def find_game_by_box_score_url(url)
-        return unless box_score_url?(url)
+      def find_game_by_unique_url(url)
+        return unless unique_game_url?(url)
 
         Game.find_by(url:)
       end
 
-      def box_score_url?(url)
-        url.to_s.include?('/cbb/boxscores/')
+      def unique_game_url?(url)
+        normalized_url = url.to_s.strip
+        normalized_url.present? && !daily_schedule_url?(normalized_url)
+      end
+
+      def daily_schedule_url?(url)
+        url.include?('/cbb/boxscores/index.cgi')
       end
 
       def find_game_by_teams_and_date(home_team_name, away_team_name, date)

--- a/app/services/importer/games_importer.rb
+++ b/app/services/importer/games_importer.rb
@@ -13,21 +13,60 @@ module Importer
 
       private
 
+      def find_existing_game(row, date)
+        find_game_by_box_score_url(row[:url]) ||
+          find_game_by_teams_and_date(row[:home_team], row[:away_team], date) ||
+          find_game_by_teams_and_legacy_date(row[:home_team], row[:away_team], date) ||
+          find_neutral_game_by_reversed_teams(row, date)
+      end
+
+      def find_game_by_box_score_url(url)
+        return unless box_score_url?(url)
+
+        Game.find_by(url:)
+      end
+
+      def box_score_url?(url)
+        url.to_s.include?('/cbb/boxscores/')
+      end
+
       def find_game_by_teams_and_date(home_team_name, away_team_name, date)
         Game.on_schedule_date(date)
             .where(home_team_name:, away_team_name:)
             .first
       end
 
+      def find_game_by_teams_and_legacy_date(home_team_name, away_team_name, date)
+        Game.where(home_team_name:, away_team_name:)
+            .where(start_time: Time.zone.local(date.year, date.month, date.day).all_day)
+            .first
+      end
+
+      def find_neutral_game_by_reversed_teams(row, date)
+        return unless neutral_row?(row)
+
+        find_game_by_teams_and_date(row[:away_team], row[:home_team], date) ||
+          find_game_by_teams_and_legacy_date(row[:away_team], row[:home_team], date)
+      end
+
+      def neutral_row?(row)
+        row[:neutral] == true || row[:venue_type] == 'neutral'
+      end
+
       def find_or_create_team_game(game, team_season, home:)
         return nil unless team_season&.team
 
-        TeamGame.find_or_create_by!(
-          game:,
-          team: team_season.team,
-          team_season:,
-          home:
-        )
+        remove_conflicting_team_game(game, team_season.team, home)
+        TeamGame.find_or_initialize_by(game:, home:).tap do |team_game|
+          team_game.update!(team: team_season.team, team_season:)
+        end
+      end
+
+      def remove_conflicting_team_game(game, team, home)
+        conflict = TeamGame.find_by(game:, team:)
+        return unless conflict && conflict.home != home
+
+        conflict.destroy!
       end
 
       def process_team_game(team_game, data, team_season, opponent_team_season)
@@ -57,7 +96,7 @@ module Importer
         home_team_season = home_team ? TeamSeason.find_by(season:, team: home_team) : nil
         away_team_season = away_team ? TeamSeason.find_by(season:, team: away_team) : nil
 
-        game = find_game_by_teams_and_date(row[:home_team], row[:away_team], date) ||
+        game = find_existing_game(row, date) ||
                Game.new(home_team_name: row[:home_team], away_team_name: row[:away_team], start_time:)
 
         return process_complete_game(game, row, season, home_team_season, away_team_season) if game_complete?(row)
@@ -69,6 +108,8 @@ module Importer
         attrs = {
           season:,
           start_time: row[:date],
+          home_team_name: row[:home_team],
+          away_team_name: row[:away_team],
           home_team_score: row[:home_team_score],
           away_team_score: row[:away_team_score],
           url: row[:url]
@@ -89,6 +130,8 @@ module Importer
         attrs = {
           season:,
           start_time: row[:date],
+          home_team_name: row[:home_team],
+          away_team_name: row[:away_team],
           url: row[:url],
           home_team_score: game.final? ? game.home_team_score : row[:home_team_score],
           away_team_score: game.final? ? game.away_team_score : row[:away_team_score]

--- a/app/services/maintenance/duplicate_games_repair.rb
+++ b/app/services/maintenance/duplicate_games_repair.rb
@@ -1,0 +1,329 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class DuplicateGamesRepair
+    Result = Struct.new(:applied, :groups, :deleted_game_ids, :reassigned_counts, keyword_init: true)
+    DuplicateGroup = Struct.new(:games, :survivor, :duplicates, :reasons, keyword_init: true)
+
+    def initialize(scope: Game.all, apply: false, output: $stdout)
+      @scope = scope
+      @apply = apply
+      @output = output
+      @deleted_game_ids = []
+      @reassigned_counts = Hash.new(0)
+    end
+
+    def call
+      groups = duplicate_groups
+      report(groups)
+      apply_repairs(groups) if apply
+
+      Result.new(
+        applied: apply,
+        groups:,
+        deleted_game_ids: deleted_game_ids,
+        reassigned_counts: reassigned_counts
+      )
+    end
+
+    private
+
+    attr_reader :scope, :apply, :output, :deleted_game_ids, :reassigned_counts
+
+    def duplicate_groups
+      game_rows = games
+      key_map = duplicate_key_map(game_rows)
+      grouped_components(game_rows, key_map).filter_map do |component_games|
+        next if component_games.size < 2
+
+        survivor = survivor_for(component_games)
+        DuplicateGroup.new(
+          games: component_games,
+          survivor:,
+          duplicates: component_games - [survivor],
+          reasons: reasons_for(component_games, key_map)
+        )
+      end
+    end
+
+    def games
+      @games ||= scope.includes(:predictions, :game_odd, :bookmaker_odds, :bet_recommendations).to_a
+    end
+
+    def duplicate_key_map(game_rows)
+      game_rows.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |game, keys|
+        duplicate_keys_for(game).each { |key| keys[key] << game }
+      end
+    end
+
+    def grouped_components(game_rows, key_map)
+      reset_union_find
+      key_map.each_value do |matching_games|
+        next if matching_games.size < 2
+
+        matching_games.combination(2) { |left, right| union(left.id, right.id) }
+      end
+
+      game_rows.group_by { |game| find(game.id) }.values
+    end
+
+    def reset_union_find
+      @parents = {}
+    end
+
+    def find(id)
+      @parents[id] ||= id
+      @parents[id] == id ? id : @parents[id] = find(@parents[id])
+    end
+
+    def union(left_id, right_id)
+      @parents[find(right_id)] = find(left_id)
+    end
+
+    def duplicate_keys_for(game)
+      keys = []
+      keys << [:unique_url, normalized_url(game.url)] if unique_game_url?(game.url)
+
+      duplicate_dates_for(game).each do |date|
+        keys << [:ordered_team_date, normalized_team(game.home_team_name), normalized_team(game.away_team_name), date]
+        next unless neutral_game?(game)
+
+        keys << [:neutral_team_date, *normalized_team_pair(game), date]
+      end
+
+      keys
+    end
+
+    def duplicate_dates_for(game)
+      dates = [game.schedule_date]
+      dates << game.start_time.in_time_zone.to_date if legacy_date_only?(game)
+      dates.uniq
+    end
+
+    def unique_game_url?(url)
+      normalized_url(url).present? && !daily_schedule_url?(url)
+    end
+
+    def normalized_url(url)
+      url.to_s.strip
+    end
+
+    def daily_schedule_url?(url)
+      normalized_url(url).include?('/cbb/boxscores/index.cgi')
+    end
+
+    def normalized_team(team_name)
+      team_name.to_s.squish.downcase
+    end
+
+    def normalized_team_pair(game)
+      [normalized_team(game.home_team_name), normalized_team(game.away_team_name)].sort
+    end
+
+    def neutral_game?(game)
+      game.neutral == true || game.venue_neutral?
+    end
+
+    def legacy_date_only?(game)
+      time = game.start_time.in_time_zone
+      time.hour.zero? && time.min.zero? && time.sec.zero?
+    end
+
+    def reasons_for(component_games, key_map)
+      key_map.filter_map do |key, matching_games|
+        key.first if (matching_games & component_games).size > 1
+      end.uniq
+    end
+
+    def survivor_for(component_games)
+      component_games.max_by { |game| [survivor_score(game), -game.id] }
+    end
+
+    def survivor_score(game)
+      score = 0
+      score += 1_000 if game.final?
+      score += 200 if complete_team_games?(game)
+      score += 100 if game.predictions.any?
+      score += 80 if game.game_odd.present?
+      score += 60 if game.bookmaker_odds.any?
+      score += 50 if game.bet_recommendations.any?
+      score += 40 if manual_venue?(game)
+      score += 25 if venue_data_present?(game)
+      score += 15 if unique_game_url?(game.url)
+      score += 10 unless legacy_date_only?(game)
+      score
+    end
+
+    def complete_team_games?(game)
+      TeamGame.where(game:).size >= 2
+    end
+
+    def manual_venue?(game)
+      game.venue_confidence == 'manual' || game.venue_source == 'manual_override'
+    end
+
+    def venue_data_present?(game)
+      !game.venue_unknown? || game.venue_source.present? || game.venue_name.present? || !game.neutral.nil?
+    end
+
+    def report(groups)
+      output.puts(apply ? 'APPLYING duplicate game repair' : 'DRY RUN duplicate game repair')
+      output.puts("Found #{groups.size} duplicate groups.")
+
+      groups.each_with_index do |group, index|
+        output.puts(group_summary(group, index + 1))
+      end
+    end
+
+    def group_summary(group, index)
+      game_ids = group.games.map(&:id).join(', ')
+      duplicate_ids = group.duplicates.map(&:id).join(', ')
+      "Group #{index}: reason=#{group.reasons.join(', ')} keep=#{group.survivor.id} " \
+        "duplicates=#{duplicate_ids} all=#{game_ids}"
+    end
+
+    def apply_repairs(groups)
+      groups.each do |group|
+        ActiveRecord::Base.transaction do
+          group.duplicates.each { |duplicate| merge_duplicate!(group.survivor, duplicate) }
+        end
+      end
+    end
+
+    def merge_duplicate!(survivor, duplicate)
+      merge_game_attributes!(survivor, duplicate)
+      reassign_team_games!(survivor, duplicate)
+      reassign_predictions!(survivor, duplicate)
+      reassign_game_odd!(survivor, duplicate)
+      reassign_bookmaker_odds!(survivor, duplicate)
+      reassign_bet_recommendations!(survivor, duplicate)
+      reset_duplicate_associations(duplicate)
+      duplicate.destroy!
+      deleted_game_ids << duplicate.id
+    end
+
+    def reset_duplicate_associations(duplicate)
+      %i[predictions game_odd bookmaker_odds bet_recommendations].each do |association_name|
+        duplicate.association(association_name).reset
+      end
+    end
+
+    def merge_game_attributes!(survivor, duplicate)
+      attrs = merged_game_attributes(survivor, duplicate)
+      return if attrs.empty?
+
+      survivor.assign_attributes(attrs)
+      survivor.save!(validate: false)
+    end
+
+    def merged_game_attributes(survivor, duplicate)
+      {}.tap do |attrs|
+        attrs[:url] = duplicate.url if !unique_game_url?(survivor.url) && unique_game_url?(duplicate.url)
+        attrs[:start_time] = duplicate.start_time if legacy_date_only?(survivor) && !legacy_date_only?(duplicate)
+        attrs.merge!(score_attributes_from(duplicate, survivor))
+        attrs.merge!(venue_attributes_from(duplicate)) if !venue_data_present?(survivor) && venue_data_present?(duplicate)
+      end
+    end
+
+    def score_attributes_from(duplicate, survivor)
+      attrs = {}
+      copy_if_blank(attrs, :home_team_score, from: duplicate, to: survivor)
+      copy_if_blank(attrs, :away_team_score, from: duplicate, to: survivor)
+      copy_if_blank(attrs, :minutes, from: duplicate, to: survivor)
+      copy_if_blank(attrs, :possessions, from: duplicate, to: survivor)
+      attrs[:status] = duplicate.status if survivor.scheduled? && duplicate.final?
+      attrs
+    end
+
+    def copy_if_blank(attrs, attribute, from:, to:)
+      value = from.public_send(attribute)
+      attrs[attribute] = value if to.public_send(attribute).blank? && value.present?
+    end
+
+    def venue_attributes_from(game)
+      {
+        venue_type: game.venue_type,
+        venue_source: game.venue_source,
+        venue_confidence: game.venue_confidence,
+        venue_name: game.venue_name,
+        neutral: game.neutral
+      }
+    end
+
+    def reassign_team_games!(survivor, duplicate)
+      TeamGame.where(game: duplicate).find_each do |team_game|
+        if TeamGame.exists?(game: survivor, home: team_game.home) || TeamGame.exists?(game: survivor, team_id: team_game.team_id)
+          team_game.destroy!
+          reassigned_counts[:team_games_deleted] += 1
+        else
+          team_game.update!(game: survivor)
+          reassigned_counts[:team_games_reassigned] += 1
+        end
+      end
+    end
+
+    def reassign_predictions!(survivor, duplicate)
+      duplicate.predictions.find_each do |prediction|
+        if matching_prediction?(survivor, prediction)
+          prediction.destroy!
+          reassigned_counts[:predictions_deleted] += 1
+        else
+          prediction.update!(game: survivor)
+          reassigned_counts[:predictions_reassigned] += 1
+        end
+      end
+    end
+
+    def matching_prediction?(survivor, prediction)
+      Prediction.exists?(
+        game: survivor,
+        home_team_snapshot_id: prediction.home_team_snapshot_id,
+        away_team_snapshot_id: prediction.away_team_snapshot_id
+      )
+    end
+
+    def reassign_game_odd!(survivor, duplicate)
+      game_odd = duplicate.game_odd
+      return unless game_odd
+
+      if survivor.game_odd
+        game_odd.destroy!
+        reassigned_counts[:game_odds_deleted] += 1
+      else
+        game_odd.update!(game: survivor)
+        survivor.association(:game_odd).reset
+        reassigned_counts[:game_odds_reassigned] += 1
+      end
+    end
+
+    def reassign_bookmaker_odds!(survivor, duplicate)
+      duplicate.bookmaker_odds.find_each do |bookmaker_odd|
+        bookmaker_odd.update!(game: survivor)
+        reassigned_counts[:bookmaker_odds_reassigned] += 1
+      end
+    end
+
+    def reassign_bet_recommendations!(survivor, duplicate)
+      duplicate.bet_recommendations.find_each do |recommendation|
+        if matching_bet_recommendation?(recommendation)
+          recommendation.destroy!
+          reassigned_counts[:bet_recommendations_deleted] += 1
+        else
+          recommendation.update!(game: survivor)
+          reassigned_counts[:bet_recommendations_reassigned] += 1
+        end
+      end
+    end
+
+    def matching_bet_recommendation?(recommendation)
+      BetRecommendation
+        .where(
+          prediction_id: recommendation.prediction_id,
+          game_odd_id: recommendation.game_odd_id,
+          bet_type: recommendation.bet_type
+        )
+        .where.not(id: recommendation.id)
+        .exists?
+    end
+  end
+end

--- a/app/services/maintenance/duplicate_games_repair.rb
+++ b/app/services/maintenance/duplicate_games_repair.rb
@@ -47,7 +47,14 @@ module Maintenance
     end
 
     def games
-      @games ||= scope.includes(:predictions, :game_odd, :bookmaker_odds, :bet_recommendations).to_a
+      @games ||= scope.includes(
+        :home_team_game,
+        :away_team_game,
+        :predictions,
+        :game_odd,
+        :bookmaker_odds,
+        :bet_recommendations
+      ).to_a
     end
 
     def duplicate_key_map(game_rows)
@@ -155,7 +162,7 @@ module Maintenance
     end
 
     def complete_team_games?(game)
-      TeamGame.where(game:).size >= 2
+      game.home_team_game.present? && game.away_team_game.present?
     end
 
     def manual_venue?(game)
@@ -203,7 +210,7 @@ module Maintenance
     end
 
     def reset_duplicate_associations(duplicate)
-      %i[predictions game_odd bookmaker_odds bet_recommendations].each do |association_name|
+      %i[home_team_game away_team_game predictions game_odd bookmaker_odds bet_recommendations].each do |association_name|
         duplicate.association(association_name).reset
       end
     end
@@ -257,9 +264,15 @@ module Maintenance
           reassigned_counts[:team_games_deleted] += 1
         else
           team_game.update!(game: survivor)
+          reset_team_game_associations(survivor)
           reassigned_counts[:team_games_reassigned] += 1
         end
       end
+    end
+
+    def reset_team_game_associations(game)
+      game.association(:home_team_game).reset
+      game.association(:away_team_game).reset
     end
 
     def reassign_predictions!(survivor, duplicate)
@@ -298,9 +311,23 @@ module Maintenance
 
     def reassign_bookmaker_odds!(survivor, duplicate)
       duplicate.bookmaker_odds.find_each do |bookmaker_odd|
-        bookmaker_odd.update!(game: survivor)
-        reassigned_counts[:bookmaker_odds_reassigned] += 1
+        if matching_bookmaker_odd?(survivor, bookmaker_odd)
+          bookmaker_odd.destroy!
+          reassigned_counts[:bookmaker_odds_deleted] += 1
+        else
+          bookmaker_odd.update!(game: survivor)
+          survivor.association(:bookmaker_odds).reset
+          reassigned_counts[:bookmaker_odds_reassigned] += 1
+        end
       end
+    end
+
+    def matching_bookmaker_odd?(survivor, bookmaker_odd)
+      survivor.bookmaker_odds.find_by(
+        bookmaker: bookmaker_odd.bookmaker,
+        market: bookmaker_odd.market,
+        team_name: bookmaker_odd.team_name
+      )
     end
 
     def reassign_bet_recommendations!(survivor, duplicate)

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -241,7 +241,7 @@ For each row, the importer:
 1. Finds the season covering `row[:date]`.
 2. Resolves home and away teams with `Team.search`.
 3. Logs if either team cannot be matched.
-4. Finds existing games by home team name, away team name, and date.
+4. Finds existing games by unique non-placeholder URL, then home team name, away team name, and Eastern schedule date. It also has a legacy raw-date fallback for old date-only imports and a neutral-site reversed-team fallback.
 5. Builds a new `Game` if no matching game exists.
 6. Creates or finds home/away `TeamGame` records when team seasons can be resolved.
 7. Writes team-game stat attributes.
@@ -439,13 +439,30 @@ It supports:
 
 File: `lib/tasks/game_dedupe.rake`
 
-Purpose: remove duplicate games grouped by:
+Purpose: report or repair duplicate games created by historical import matching issues.
 
-- `home_team_name`
-- `away_team_name`
-- `schedule_date`
+By default this task is a dry run:
 
-It keeps the lowest-id game and deletes duplicate associated `TeamGame` rows. It also deletes odds associations if those classes are defined.
+```bash
+bin/rails games:dedupe
+```
+
+The task looks for duplicate groups using the same conservative identifiers used by the importer:
+
+- unique non-placeholder game URLs
+- ordered teams plus Eastern schedule date
+- ordered teams plus legacy raw stored date for old date-only rows
+- neutral-site unordered team pairs plus schedule date
+
+It chooses a survivor by preferring finalized games, complete `TeamGame` data, predictions/odds, manual or known venue data, unique URLs, and then lower ids as a tie breaker. In dry-run mode it only prints the groups and planned survivor.
+
+To repair records, set `APPLY=true`:
+
+```bash
+APPLY=true bin/rails games:dedupe
+```
+
+The apply mode reassigns safe dependent records such as `TeamGame`, `Prediction`, `GameOdd`, `BookmakerOdd`, and `BetRecommendation` where unique constraints allow it, deletes conflicting duplicate dependents, and then deletes duplicate `Game` records. You can restrict the scope with `YEAR=<year>` or `SEASON_ID=<id>`.
 
 Use this carefully because it deletes records.
 
@@ -491,7 +508,7 @@ docker compose exec web bin/setup_data
 ## Data integrity notes
 
 - Team identity is resolved by `Team.search` and team aliases. If team names change upstream, update aliases rather than hardcoding importer exceptions when possible.
-- Games are matched by home team name, away team name, and Eastern schedule date. Be careful changing matching logic because duplicate games can affect ratings and snapshots.
+- Games are matched first by unique non-placeholder URL, then by home team name, away team name, and Eastern schedule date, with legacy and neutral-site fallbacks. Be careful changing matching logic because duplicate games can affect ratings and snapshots.
 - Scheduled rows intentionally preserve games without complete stats.
 - Complete rows must include all required stats before finalization is attempted.
 - Finalized games should not be overwritten by later partial/scheduled rows.

--- a/lib/tasks/game_dedupe.rake
+++ b/lib/tasks/game_dedupe.rake
@@ -1,27 +1,20 @@
 # frozen_string_literal: true
 
 namespace :games do
-  desc 'Deduplicate games by home_team_name, away_team_name, and Eastern schedule date, deleting duplicates and their associations.'
+  desc 'Report duplicate games by default; set APPLY=true to repair/delete duplicates.'
   task dedupe: :environment do
-    require 'active_record'
+    scope = if ENV['SEASON_ID'].present?
+              Season.find(ENV.fetch('SEASON_ID')).games
+            elsif ENV['YEAR'].present?
+              Season.find_by!(year: ENV.fetch('YEAR')).games
+            else
+              Game.all
+            end
 
-    grouped = Game.all.group_by { |g| [g.home_team_name, g.away_team_name, g.schedule_date] }
-    dup_groups = grouped.select { |_k, games| games.size > 1 }
-    puts "Found \\#{dup_groups.size} duplicate groups."
-    dup_groups.each do |key, games|
-      keep = games.min_by(&:id)
-      dups = games - [keep]
-      next if dups.empty?
+    apply = ActiveModel::Type::Boolean.new.cast(ENV.fetch('APPLY', false))
+    result = Maintenance::DuplicateGamesRepair.new(scope:, apply:).call
 
-      puts "Keeping game id=\\#{keep.id} (\\#{key.inspect}), deleting duplicates: \\#{dups.map(&:id).join(', ')}"
-      dups.each do |dup|
-        TeamGame.where(game_id: dup.id).delete_all
-        GameOdd.where(game_id: dup.id).delete_all if defined?(GameOdd)
-        BookmakerOdd.where(game_id: dup.id).delete_all if defined?(BookmakerOdd)
-        # Add any other associations here as needed
-        dup.destroy
-      end
-    end
-    puts 'Deduplication complete.'
+    puts "Deleted games: #{result.deleted_game_ids.join(', ')}" if result.deleted_game_ids.any?
+    puts "Reassigned/deleted associations: #{result.reassigned_counts.inspect}" if result.reassigned_counts.any?
   end
 end

--- a/spec/services/importer/games_importer_spec.rb
+++ b/spec/services/importer/games_importer_spec.rb
@@ -277,6 +277,83 @@ RSpec.describe Importer::GamesImporter do
     expect(existing_game.reload.url).to eq('http://example.com/enriched-game')
   end
 
+  it 'matches existing games by box score URL when the stored date is a legacy UTC date' do
+    box_score_url = '/cbb/boxscores/2025-01-01-00-home.html'
+    existing_game = create(
+      :game,
+      season:,
+      start_time: Time.zone.local(2025, 1, 1),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: box_score_url
+    )
+
+    late_row = row.merge(
+      date: ActiveSupport::TimeZone['Eastern Time (US & Canada)'].parse('2025-01-01 9:00pm'),
+      url: box_score_url
+    )
+
+    expect do
+      described_class.import([late_row])
+    end.not_to change(Game, :count)
+    expect(existing_game.reload.start_time).to eq(late_row[:date])
+  end
+
+  it 'matches existing neutral games by box score URL when stored teams are reversed' do
+    box_score_url = '/cbb/boxscores/2025-01-01-00-neutral.html'
+    existing_game = create(
+      :game,
+      season:,
+      start_time: Time.zone.local(2025, 1, 1),
+      home_team_name: away_team.school,
+      away_team_name: home_team.school,
+      url: box_score_url,
+      venue_type: 'neutral',
+      neutral: true
+    )
+    create(:team_game, game: existing_game, team: away_team, team_season: away_team_season, home: true)
+    create(:team_game, game: existing_game, team: home_team, team_season: home_team_season, home: false)
+
+    neutral_row = row.merge(
+      url: box_score_url,
+      venue_type: 'neutral',
+      venue_name: 'Neutral Arena',
+      neutral: true
+    )
+
+    expect do
+      described_class.import([neutral_row])
+    end.not_to change(Game, :count)
+    expect(existing_game.reload).to have_attributes(
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      venue_name: 'Neutral Arena'
+    )
+    expect(existing_game.home_team_game.team).to eq(home_team)
+    expect(existing_game.away_team_game.team).to eq(away_team)
+  end
+
+  it 'matches legacy UTC-date games by teams and raw stored date' do
+    existing_game = create(
+      :game,
+      season:,
+      start_time: Time.zone.local(2025, 1, 1),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: 'http://example.com/old-game'
+    )
+
+    late_row = row.merge(
+      date: ActiveSupport::TimeZone['Eastern Time (US & Canada)'].parse('2025-01-01 9:00pm'),
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+
+    expect do
+      described_class.import([late_row])
+    end.not_to change(Game, :count)
+    expect(existing_game.reload.url).to eq('/cbb/boxscores/2025-01-01-00-home.html')
+  end
+
   it 'keeps incomplete games scheduled' do
     described_class.import([row])
     expect(Game.last).to be_scheduled

--- a/spec/services/importer/games_importer_spec.rb
+++ b/spec/services/importer/games_importer_spec.rb
@@ -256,6 +256,24 @@ RSpec.describe Importer::GamesImporter do
     end.not_to change(Game, :count)
   end
 
+  it 'does not match different scheduled games by shared daily schedule URL' do
+    other_home_team = create(:team, school: 'Other Home', slug: 'other-home')
+    other_away_team = create(:team, school: 'Other Away', slug: 'other-away')
+    other_home_season = create(:team_season, team: other_home_team, season:)
+    other_away_season = create(:team_season, team: other_away_team, season:)
+    create(:team_alias, team: other_home_team, value: other_home_team.school, source: 'sports_reference')
+    create(:team_alias, team: other_away_team, value: other_away_team.school, source: 'sports_reference')
+    daily_schedule_url = 'https://www.sports-reference.com/cbb/boxscores/index.cgi?month=1&day=1&year=2025'
+    other_row = row.merge(
+      home_team: other_home_season.team.school,
+      away_team: other_away_season.team.school
+    )
+
+    expect do
+      described_class.import([row.merge(url: daily_schedule_url), other_row.merge(url: daily_schedule_url)])
+    end.to change(Game, :count).by(2)
+  end
+
   it 'matches existing games by Eastern schedule date when enriched start time crosses UTC midnight' do
     existing_game = create(
       :game,

--- a/spec/services/maintenance/duplicate_games_repair_spec.rb
+++ b/spec/services/maintenance/duplicate_games_repair_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe Maintenance::DuplicateGamesRepair do
     build(:game, attrs).tap { |game| game.save!(validate: false) }
   end
 
+  def create_bookmaker_odd_for(game)
+    create(
+      :bookmaker_odd,
+      game:,
+      bookmaker: 'DraftKings',
+      fetched_at: Time.current,
+      market: 'h2h',
+      team_name: home_team.school
+    )
+  end
+
   it 'reports duplicate groups without mutating records by default' do
     create_game(
       season:,
@@ -99,6 +110,33 @@ RSpec.describe Maintenance::DuplicateGamesRepair do
     expect(survivor.reload.home_team_game.team).to eq(home_team)
     expect(survivor.away_team_game.team).to eq(away_team)
     expect(Game.exists?(duplicate.id)).to be(false)
+  end
+
+  it 'deletes duplicate bookmaker odds when the survivor already has the same sportsbook market' do
+    survivor = create_game(
+      season:,
+      status: :final,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 9:00pm'),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+    duplicate = create_game(
+      season:,
+      status: :scheduled,
+      start_time: Time.zone.local(2025, 1, 1),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+    survivor_odd = create_bookmaker_odd_for(survivor)
+    duplicate_odd = create_bookmaker_odd_for(duplicate)
+
+    result = described_class.new(apply: true, output:).call
+
+    expect(BookmakerOdd.exists?(duplicate_odd.id)).to be(false)
+    expect(survivor_odd.reload.game).to eq(survivor)
+    expect(result.reassigned_counts[:bookmaker_odds_deleted]).to eq(1)
   end
 
   it 'detects reversed neutral duplicates by unordered team pair and schedule date' do

--- a/spec/services/maintenance/duplicate_games_repair_spec.rb
+++ b/spec/services/maintenance/duplicate_games_repair_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Maintenance::DuplicateGamesRepair do
+  let(:season) { create(:season, year: 2025, start_date: '2024-11-01', end_date: '2025-04-10') }
+  let(:home_team) { create(:team, school: 'Home School') }
+  let(:away_team) { create(:team, school: 'Away School') }
+  let(:home_team_season) { create(:team_season, team: home_team, season:) }
+  let(:away_team_season) { create(:team_season, team: away_team, season:) }
+  let(:output) { StringIO.new }
+
+  def create_game(attrs)
+    build(:game, attrs).tap { |game| game.save!(validate: false) }
+  end
+
+  it 'reports duplicate groups without mutating records by default' do
+    create_game(
+      season:,
+      start_time: Time.zone.local(2025, 1, 1),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+    create_game(
+      season:,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 9:00pm'),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+
+    result = described_class.new(output:).call
+
+    expect(result.applied).to be(false)
+    expect(result.groups.size).to eq(1)
+    expect(result.deleted_game_ids).to be_empty
+    expect(Game.count).to eq(2)
+    expect(output.string).to include('DRY RUN')
+  end
+
+  it 'applies repairs by keeping the strongest survivor and deleting duplicates' do
+    scheduled_duplicate = create_game(
+      season:,
+      status: :scheduled,
+      start_time: Time.zone.local(2025, 1, 1),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+    final_survivor = create_game(
+      season:,
+      status: :final,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 9:00pm'),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html',
+      venue_type: 'home',
+      venue_confidence: 'confirmed',
+      venue_name: 'Home Arena'
+    )
+    create(:team_game, game: final_survivor, team: home_team, team_season: home_team_season, home: true)
+    create(:team_game, game: final_survivor, team: away_team, team_season: away_team_season, home: false)
+
+    result = described_class.new(apply: true, output:).call
+
+    expect(result.applied).to be(true)
+    expect(result.deleted_game_ids).to contain_exactly(scheduled_duplicate.id)
+    expect(Game.exists?(scheduled_duplicate.id)).to be(false)
+    expect(Game.exists?(final_survivor.id)).to be(true)
+  end
+
+  it 'reassigns safe dependent records before deleting a duplicate' do
+    survivor = create_game(
+      season:,
+      status: :final,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 9:00pm'),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+    duplicate = create_game(
+      season:,
+      status: :scheduled,
+      start_time: Time.zone.local(2025, 1, 1),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: '/cbb/boxscores/2025-01-01-00-home.html'
+    )
+    game_odd = create(:game_odd, game: duplicate, fetched_at: Time.current)
+    bookmaker_odd = create(:bookmaker_odd, game: duplicate, bookmaker: 'DraftKings', fetched_at: Time.current, market: 'h2h')
+    create(:team_game, game: duplicate, team: home_team, team_season: home_team_season, home: true)
+    create(:team_game, game: duplicate, team: away_team, team_season: away_team_season, home: false)
+
+    described_class.new(apply: true, output:).call
+
+    expect(game_odd.reload.game).to eq(survivor)
+    expect(bookmaker_odd.reload.game).to eq(survivor)
+    expect(survivor.reload.home_team_game.team).to eq(home_team)
+    expect(survivor.away_team_game.team).to eq(away_team)
+    expect(Game.exists?(duplicate.id)).to be(false)
+  end
+
+  it 'detects reversed neutral duplicates by unordered team pair and schedule date' do
+    create_game(
+      season:,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 9:00pm'),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: 'https://www.sports-reference.com/cbb/boxscores/index.cgi?month=1&day=1&year=2025',
+      venue_type: 'neutral',
+      neutral: true
+    )
+    create_game(
+      season:,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 9:30pm'),
+      home_team_name: away_team.school,
+      away_team_name: home_team.school,
+      url: 'https://www.sports-reference.com/cbb/boxscores/index.cgi?month=1&day=1&year=2025',
+      venue_type: 'neutral',
+      neutral: true
+    )
+
+    result = described_class.new(output:).call
+
+    expect(result.groups.size).to eq(1)
+    expect(result.groups.first.games.map(&:id).size).to eq(2)
+  end
+
+  it 'does not group unrelated games by shared daily schedule URL' do
+    create_game(
+      season:,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 7:00pm'),
+      home_team_name: home_team.school,
+      away_team_name: away_team.school,
+      url: 'https://www.sports-reference.com/cbb/boxscores/index.cgi?month=1&day=1&year=2025'
+    )
+    create_game(
+      season:,
+      start_time: Game::SCHEDULE_TIME_ZONE.parse('2025-01-01 9:00pm'),
+      home_team_name: 'Other Home',
+      away_team_name: 'Other Away',
+      url: 'https://www.sports-reference.com/cbb/boxscores/index.cgi?month=1&day=1&year=2025'
+    )
+
+    result = described_class.new(output:).call
+
+    expect(result.groups).to be_empty
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a maintenance repair tool to detect and safely merge duplicate games (dry-run and apply modes).
  * Updated dedupe task to use the new repair tool with env-driven scope and apply flag.

* **Bug Fixes**
  * Improved importer matching to avoid false duplicates and better match existing games (including neutral-site and legacy-date cases).
  * Resolved conflicting team-home assignments and ensured team names/scores/times are consistently updated on import.

* **Documentation**
  * Updated data ingestion docs to reflect new matching and dedupe behavior.

* **Tests**
  * Added specs covering importer matching and duplicate-repair behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zstearman3/prophet-ratings/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->